### PR TITLE
Supports MySQL/Maria grants containing percent symbols.

### DIFF
--- a/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
@@ -188,7 +188,8 @@ def set_secret(service_client, arn, token):
             for row in cur.fetchall():
                 grant = row[0].split(' TO ')
                 new_grant = "%s TO %s" % (grant[0], pending_dict['username'])
-                cur.execute(new_grant + " IDENTIFIED BY %s", pending_dict['password'])
+                new_grant_escaped = new_grant.replace('%','%%') # % is a special character in Python format strings.
+                cur.execute(new_grant_escaped + " IDENTIFIED BY %s", pending_dict['password'])
             conn.commit()
             logger.info("setSecret: Successfully set password for %s in MariaDB DB for secret arn %s." % (pending_dict['username'], arn))
     finally:

--- a/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
@@ -188,7 +188,8 @@ def set_secret(service_client, arn, token):
             for row in cur.fetchall():
                 grant = row[0].split(' TO ')
                 new_grant = "%s TO '%s'" % (grant[0], pending_dict['username'])
-                cur.execute(new_grant + " IDENTIFIED BY %s", pending_dict['password'])
+                new_grant_escaped = new_grant.replace('%','%%') # % is a special character in Python format strings.
+                cur.execute(new_grant_escaped + " IDENTIFIED BY %s", pending_dict['password'])
             conn.commit()
             logger.info("setSecret: Successfully set password for %s in MySQL DB for secret arn %s." % (pending_dict['username'], arn))
     finally:


### PR DESCRIPTION
*Description of changes:*
The rotation functions modified in this PR are breaking when processing grants containing percent symbols on the grant itself, like in:
```
  GRANT ALL PRIVILEGES ON `testing%`.* TO 'test'@'%' 
```
This is because a grant substring containing percent symbols was used to build a format string, where `%` is a special character that needs to be replaced by `%%` to be taken literally.

So, this change just makes sure that the percent symbols are escaped.