### PR TITLE
exclude colon from password generator for Postgres

### DIFF
--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -120,7 +120,7 @@ def create_secret(service_client, arn, token):
         current_dict['username'] = get_alt_username(current_dict['username'])
 
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=':/@"\'\\')
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret

--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
@@ -114,7 +114,7 @@ def create_secret(service_client, arn, token):
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters='/@"\'\\')
+        passwd = service_client.get_random_password(ExcludeCharacters=':/@"\'\\')
         current_dict['password'] = passwd['RandomPassword']
 
         # Put the secret


### PR DESCRIPTION
*Issue #, if available:* 9

*Description of changes:* add colon character to list of characters excluded from randomly generated passwords for Postgres


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
