### PR TITLE
Database Connection Failure logging

### DIFF
--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -48,6 +48,8 @@ def lambda_handler(event, context):
     token = event['ClientRequestToken']
     step = event['Step']
 
+    logger.info("Step %s" % step)
+
     # Setup the client
     service_client = boto3.client('secretsmanager', endpoint_url=os.environ['SECRETS_MANAGER_ENDPOINT'])
 
@@ -156,6 +158,7 @@ def set_secret(service_client, arn, token):
     if not conn:
         # If both current and pending do not work, try previous
         try:
+            logger.info("setSecret: trying using AWSPREVIOUS, unable to connect using  AWSPENDING and AWSCURRENT")
             conn = get_connection(get_secret_dict(service_client, arn, "AWSPREVIOUS"))
         except service_client.exceptions.ResourceNotFoundException:
             conn = None
@@ -270,6 +273,10 @@ def get_connection(secret_dict):
         conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5)
         return conn
     except pymysql.OperationalError:
+        logger.exception("Unable to open database connection")
+        return None
+    except:
+        logger.exception("Unknown error opening database connection")
         return None
 
 

--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -48,7 +48,7 @@ def lambda_handler(event, context):
     token = event['ClientRequestToken']
     step = event['Step']
 
-    logger.info("Step %s" % step)
+    logger.debug("Step %s" % step)
 
     # Setup the client
     service_client = boto3.client('secretsmanager', endpoint_url=os.environ['SECRETS_MANAGER_ENDPOINT'])

--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -158,9 +158,10 @@ def set_secret(service_client, arn, token):
     if not conn:
         # If both current and pending do not work, try previous
         try:
-            logger.info("setSecret: trying using AWSPREVIOUS, unable to connect using  AWSPENDING and AWSCURRENT")
+            logger.info("setSecret: Trying using previous secret, unable to log into database with pending and current secret of secret arn %s" % arn)
             conn = get_connection(get_secret_dict(service_client, arn, "AWSPREVIOUS"))
         except service_client.exceptions.ResourceNotFoundException:
+            logger.exception("setSecret: Unable to find previous secret of secret arn %s" % arn)
             conn = None
 
     # If we still don't have a connection, raise a ValueError


### PR DESCRIPTION
*Issue #, if available:*
When the rotation lambda is unable to connect to the Lambda, the database operational error is not logged. The rotation lambda attempt AWSPENDING, AWSCURRENT, then AWSPREVIOUS.

On the initial rotation AWSPREVIOUS does not have the required engine and host data.

As a result, the only information logged is that AWSPREVIOUS is missing the required fields.

This is to provide error messages back to the customer regarding the actual issue. That the Lambda is having database connectivity issue. The customer can then troubleshoot accordingly (e.g., VPC, Security Group).

*Description of changes:*
Adding logger exception information.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
