### PR TITLE
Use psycopg2 for PostgreSQL DB operations

### DIFF
--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -5,8 +5,7 @@ import boto3
 import json
 import logging
 import os
-import pg
-import pgdb
+import psycopg2
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -304,7 +303,7 @@ def get_connection(secret_dict):
         secret_dict (dict): The Secret Dictionary
 
     Returns:
-        Connection: The pgdb.Connection object if successful. None otherwise
+        Connection: The psycopg2.Connection object if successful. None otherwise
 
     Raises:
         KeyError: If the secret json does not contain the expected keys
@@ -316,9 +315,16 @@ def get_connection(secret_dict):
 
     # Try to obtain a connection to the db
     try:
-        conn = pgdb.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], database=dbname, port=port, connect_timeout=5)
+        conn = psycopg2.connect(
+            host=secret_dict['host'],
+            user=secret_dict['username'],
+            password=secret_dict['password'],
+            database=dbname,
+            port=port,
+            connect_timeout=5,
+        )
         return conn
-    except pg.InternalError:
+    except psycopg2.Error:
         return None
 
 

--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
@@ -5,8 +5,7 @@ import boto3
 import json
 import logging
 import os
-import pg
-import pgdb
+import psycopg2
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -285,7 +284,7 @@ def get_connection(secret_dict):
         secret_dict (dict): The Secret Dictionary
 
     Returns:
-        Connection: The pgdb.Connection object if successful. None otherwise
+        Connection: The psycopg2.Connection object if successful. None otherwise
 
     Raises:
         KeyError: If the secret json does not contain the expected keys
@@ -297,9 +296,16 @@ def get_connection(secret_dict):
 
     # Try to obtain a connection to the db
     try:
-        conn = pgdb.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], database=dbname, port=port, connect_timeout=5)
+        conn = psycopg2.connect(
+            host=secret_dict['host'],
+            user=secret_dict['username'],
+            password=secret_dict['password'],
+            database=dbname,
+            port=port,
+            connect_timeout=5,
+        )
         return conn
-    except pg.InternalError:
+    except psycopg2.Error:
         return None
 
 


### PR DESCRIPTION
*Issue #, if available:*
Partially related to #24.

*Description of changes:*
Updated the PostgreSQL rotation functions to use psycopg2. I've confirmed using this that I can successfully rotate credentials for the single user rotation use case in the AWS Lambda Python 3.7 runtime.

This was mainly motivated by issues I encountered trying to get `pg` and `pgdb` packaged properly for Lambda. Since I am using Terraform to deploy the secret and its rotation function I cannot rely on the serverless application repository version usually deployed via the console. This has the nice side effect of making the deployment package much smaller, since for some reason pip installing `pg` or `pgdb` installs a bunch of OpenGL stuff.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
