### PR TITLE
Fixes bug with documentDB lambda ssl parameter in python 2 runtime

### DIFF
--- a/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
@@ -285,7 +285,7 @@ def get_connection(secret_dict):
     dbname = secret_dict['dbname'] if 'dbname' in secret_dict else "admin"
     ssl = False
     if 'ssl' in secret_dict:
-        ssl = (secret_dict['ssl'].lower() == "true") if type(secret_dict['ssl']) is str else bool(secret_dict['ssl'])
+        ssl = (secret_dict['ssl'].lower() == "true") if type(secret_dict['ssl']) in [str, unicode] else bool(secret_dict['ssl'])
 
     # Try to obtain a connection to the db
     try:

--- a/SecretsManagerMongoDBRotationSingleUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationSingleUser/lambda_function.py
@@ -264,7 +264,7 @@ def get_connection(secret_dict):
     dbname = secret_dict['dbname'] if 'dbname' in secret_dict else "admin"
     ssl = False
     if 'ssl' in secret_dict:
-        ssl = (secret_dict['ssl'].lower() == "true") if type(secret_dict['ssl']) is str else bool(secret_dict['ssl'])
+        ssl = (secret_dict['ssl'].lower() == "true") if type(secret_dict['ssl']) in [str, unicode] else bool(secret_dict['ssl'])
 
     # Try to obtain a connection to the db
     try:


### PR DESCRIPTION
*Issue #, if available:* 0306483884

As per https://python-gtk-3-tutorial.readthedocs.io/en/latest/unicode.html#python-2-xs-unicode-support

python 2.x interprets strings as str and unicode but python 3.x treats everything as str.

Fixes for the python 2.x where customer has ssl = "false" in secret value for doc db

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
