### PR TITLE
Fixed the issue with type unicode not found in python 3.x runtime

### DIFF
--- a/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
@@ -285,7 +285,10 @@ def get_connection(secret_dict):
     dbname = secret_dict['dbname'] if 'dbname' in secret_dict else "admin"
     ssl = False
     if 'ssl' in secret_dict:
-        ssl = (secret_dict['ssl'].lower() == "true") if type(secret_dict['ssl']) in [str, unicode] else bool(secret_dict['ssl'])
+        if type(secret_dict['ssl']) is bool:
+	        ssl = secret_dict['ssl']
+	    else:
+	        ssl = (secret_dict['ssl'].lower() == "true")
 
     # Try to obtain a connection to the db
     try:

--- a/SecretsManagerMongoDBRotationSingleUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationSingleUser/lambda_function.py
@@ -264,8 +264,11 @@ def get_connection(secret_dict):
     dbname = secret_dict['dbname'] if 'dbname' in secret_dict else "admin"
     ssl = False
     if 'ssl' in secret_dict:
-        ssl = (secret_dict['ssl'].lower() == "true") if type(secret_dict['ssl']) in [str, unicode] else bool(secret_dict['ssl'])
-
+        if type(secret_dict['ssl']) is bool:
+	        ssl = secret_dict['ssl']
+	    else:
+	        ssl = (secret_dict['ssl'].lower() == "true")
+            
     # Try to obtain a connection to the db
     try:
         client = MongoClient(host=secret_dict['host'], port=port, connectTimeoutMS=5000, serverSelectionTimeoutMS=5000, ssl=ssl)


### PR DESCRIPTION
*Issue #, if available:* CR-20078346

*Description of changes:*

Python 3.x runtime doesn't have unicode so it throws an error. Fixing the logic to check for the ssl parameter and make it compatible with both python 2.x and 3.x 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
