### PR TITLE
missing engine is not a cause for panic

### DIFF
--- a/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
@@ -340,7 +340,9 @@ def get_secret_dict(service_client, arn, stage, token=None):
     secret_dict = json.loads(plaintext)
 
     # Run validations against the secret
-    if 'engine' not in secret_dict or secret_dict['engine'] != 'mysql':
+    if 'engine' not in secret_dict:
+        secret_dict['engine'] = 'mysql'
+    if secret_dict['engine'] != 'mysql':
         raise KeyError("Database engine must be set to 'mysql' in order to use this rotation lambda")
     for field in required_fields:
         if field not in secret_dict:

--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -310,7 +310,9 @@ def get_secret_dict(service_client, arn, stage, token=None):
     secret_dict = json.loads(plaintext)
 
     # Run validations against the secret
-    if 'engine' not in secret_dict or secret_dict['engine'] != 'mysql':
+    if 'engine' not in secret_dict:
+        secret_dict['engine'] = 'mysql'
+    if secret_dict['engine'] != 'mysql':
         raise KeyError("Database engine must be set to 'mysql' in order to use this rotation lambda")
     for field in required_fields:
         if field not in secret_dict:

--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -337,7 +337,9 @@ def get_secret_dict(service_client, arn, stage, token=None):
     secret_dict = json.loads(plaintext)
 
     # Run validations against the secret
-    if 'engine' not in secret_dict or secret_dict['engine'] != 'postgres':
+    if 'engine' not in secret_dict:
+        secret_dict['engine'] = 'postgres'
+    if secret_dict['engine'] != 'postgres':
         raise KeyError("Database engine must be set to 'postgres' in order to use this rotation lambda")
     for field in required_fields:
         if field not in secret_dict:

--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
@@ -309,7 +309,9 @@ def get_secret_dict(service_client, arn, stage, token=None):
     secret_dict = json.loads(plaintext)
 
     # Run validations against the secret
-    if 'engine' not in secret_dict or secret_dict['engine'] != 'postgres':
+    if 'engine' not in secret_dict:
+        secret_dict['engine'] = 'postgres'
+    if secret_dict['engine'] != 'postgres':
         raise KeyError("Database engine must be set to 'postgres' in order to use this rotation lambda")
     for field in required_fields:
         if field not in secret_dict:


### PR DESCRIPTION
If engine is missing, assume that the user still wants to rotate the secret.
If the user deliberatly tries to connect to a non-postgres database,
the right place to fail is in the db.connect() call.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
