### PR TITLE
Fixes issue 47 & 48

### DIFF
--- a/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
@@ -198,8 +198,9 @@ def set_secret(service_client, arn, token):
                 cur.execute("SELECT DBMS_METADATA.GET_GRANTED_DDL('%s', '%s') FROM DUAL" % (grant_type, current_dict['username'].upper()))
                 results = cur.fetchall()
                 for row in results:
-                    sql = row[0].read().strip(' \n\t').replace("\"%s\"" % current_dict['username'].upper(), "\"%s\"" % pending_dict['username'])
-                    cur.execute(sql)
+                    sqls = row[0].read().strip(' \n\t').replace("\"%s\"" % current_dict['username'].upper(), "\"%s\"" % pending_dict['username'])
+                    for sql in sqls.split('\n'):
+                        cur.execute(sql)
             except cx_Oracle.DatabaseError:
                 # If we were unable to find any grants skip this type
                 pass
@@ -298,7 +299,7 @@ def get_connection(secret_dict):
 
     # Try to obtain a connection to the db
     try:
-        conn = cx_Oracle.connect(secret_dict['username'] + '/' + secret_dict['password'] + '@' + secret_dict['host'] + ':' + port + '/' + secret_dict['dbname'])
+        conn = cx_Oracle.connect(secret_dict['username'],secret_dict['password'],secret_dict['host'] + ':' + port + '/' + secret_dict['dbname'])
         return conn
     except (cx_Oracle.DatabaseError, cx_Oracle.OperationalError) :
         return None


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-secrets-manager-rotation-lambdas/issues/47
https://github.com/aws-samples/aws-secrets-manager-rotation-lambdas/issues/48

*Description of changes:*
Line#201 - 203 fixes the bug if the GET_GRANTED_DDL contains more than one sql.

Line#302 fixes the bug of failing to connect if the password originally contains @ symbol

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
