### PR TITLE
Add execution of SQL statement for adding original user roles to clon…

### DIFF
--- a/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
@@ -500,6 +500,9 @@ def apply_database_permissions(cursor, current_user, pending_user):
     for row in cursor.fetchall():
         sql_stmt = "ALTER ROLE %s ADD MEMBER %s" % (row['name'], pending_user)
 
+        # Assign each role from the current user to the pending user
+        cursor.execute(sql_stmt)
+
     # Loop through the database permissions and grant them to the user
     query = "SELECT "\
                 "class = perm.class, "\


### PR DESCRIPTION
…ed user in SecretsManagerRDSSQLServerRotationMultiUser

*Issue #, if available:*

*Description of changes:*
Adds execution of line 501 in the SecretsManagerRDSSQLServerRotationMultiUser rotation lambda to add the original user's database roles to the cloned user as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
