### PR TITLE
Update pymysql connection arguments

### DIFF
--- a/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
@@ -154,7 +154,7 @@ def set_secret(service_client, arn, token):
     """
     current_dict = get_secret_dict(service_client, arn, "AWSCURRENT")
     pending_dict = get_secret_dict(service_client, arn, "AWSPENDING", token)
-    
+
     # First try to login with the pending secret, if it succeeds, return
     conn = get_connection(pending_dict)
     if conn:
@@ -304,7 +304,7 @@ def get_connection(secret_dict):
 
     # Try to obtain a connection to the db
     try:
-        conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5)
+        conn = pymysql.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], port=port, database=dbname, connect_timeout=5)
         return conn
     except pymysql.OperationalError:
         return None

--- a/SecretsManagerRDSMariaDBRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationSingleUser/lambda_function.py
@@ -290,7 +290,7 @@ def get_connection(secret_dict):
 
     # Try to obtain a connection to the db
     try:
-        conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5)
+        conn = pymysql.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], port=port, database=dbname, connect_timeout=5)
         return conn
     except pymysql.OperationalError:
         return None

--- a/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
@@ -314,7 +314,7 @@ def get_connection(secret_dict):
 
     # Try to obtain a connection to the db
     try:
-        conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5)
+        conn = pymysql.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], port=port, database=dbname, connect_timeout=5)
         return conn
     except pymysql.OperationalError:
         return None

--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -293,7 +293,7 @@ def get_connection(secret_dict):
 
     # Try to obtain a connection to the db
     try:
-        conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5)
+        conn = pymysql.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], port=port, database=dbname, connect_timeout=5)
         return conn
     except pymysql.OperationalError:
         return None


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
The pymsql.connect function doesn't work with the provided arguments on the current version of pymysql, resulting in this error:

 `TypeError: __init__() takes 1 positional argument but 2 positional arguments (and 5 keyword-only arguments) were given`

According to the documentation `passwd` and `db` are deprecated aliases, and the host must be defined as `host=`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
