### PR TITLE
Upgrade Pymysql connection keywords

### DIFF
--- a/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
@@ -395,7 +395,7 @@ def connect_and_authenticate(secret_dict, port, dbname, use_ssl):
     # Try to obtain a connection to the db
     try:
         # Checks hostname and verifies server certificate implictly when 'ca' key is in 'ssl' dictionary
-        conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5, ssl=ssl)
+        conn = pymysql.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], port=port, database=dbname, connect_timeout=5, ssl=ssl)
         logger.info("Successfully established %s connection as user '%s' with host: '%s'" % ("SSL/TLS" if use_ssl else "non SSL/TLS", secret_dict['username'], secret_dict['host']))
         return conn
     except pymysql.OperationalError as e:

--- a/SecretsManagerRDSMariaDBRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationSingleUser/lambda_function.py
@@ -372,7 +372,7 @@ def connect_and_authenticate(secret_dict, port, dbname, use_ssl):
     # Try to obtain a connection to the db
     try:
         # Checks hostname and verifies server certificate implictly when 'ca' key is in 'ssl' dictionary
-        conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5, ssl=ssl)
+        conn = pymysql.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], port=port, database=dbname, connect_timeout=5, ssl=ssl)
         logger.info("Successfully established %s connection as user '%s' with host: '%s'" % ("SSL/TLS" if use_ssl else "non SSL/TLS", secret_dict['username'], secret_dict['host']))
         return conn
     except pymysql.OperationalError as e:

--- a/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
@@ -407,7 +407,7 @@ def connect_and_authenticate(secret_dict, port, dbname, use_ssl):
     # Try to obtain a connection to the db
     try:
         # Checks hostname and verifies server certificate implictly when 'ca' key is in 'ssl' dictionary
-        conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5, ssl=ssl)
+        conn = pymysql.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], port=port, database=dbname, connect_timeout=5, ssl=ssl)
         logger.info("Successfully established %s connection as user '%s' with host: '%s'" % ("SSL/TLS" if use_ssl else "non SSL/TLS", secret_dict['username'], secret_dict['host']))
         return conn
     except pymysql.OperationalError as e:

--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -375,7 +375,7 @@ def connect_and_authenticate(secret_dict, port, dbname, use_ssl):
     # Try to obtain a connection to the db
     try:
         # Checks hostname and verifies server certificate implictly when 'ca' key is in 'ssl' dictionary
-        conn = pymysql.connect(secret_dict['host'], user=secret_dict['username'], passwd=secret_dict['password'], port=port, db=dbname, connect_timeout=5, ssl=ssl)
+        conn = pymysql.connect(host=secret_dict['host'], user=secret_dict['username'], password=secret_dict['password'], port=port, database=dbname, connect_timeout=5, ssl=ssl)
         logger.info("Successfully established %s connection as user '%s' with host: '%s'" % ("SSL/TLS" if use_ssl else "non SSL/TLS", secret_dict['username'], secret_dict['host']))
         return conn
     except pymysql.OperationalError as e:


### PR DESCRIPTION
Using pymysql 1.0.x, replace connection keywords set.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
