### PR TITLE
Add support 'aurora-postgres' engine

### DIFF
--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -467,7 +467,7 @@ def get_secret_dict(service_client, arn, stage, token=None, master_secret=False)
         if field not in secret_dict:
             raise KeyError("%s key is missing from secret JSON" % field)
 
-    if secret_dict['engine'] != 'postgres':
+    if 'postgres' not in secret_dict['engine']:
         raise KeyError("Database engine must be set to 'postgres' in order to use this rotation lambda")
 
     # Parse and return the secret JSON string

--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
@@ -429,7 +429,7 @@ def get_secret_dict(service_client, arn, stage, token=None):
     secret_dict = json.loads(plaintext)
 
     # Run validations against the secret
-    if 'engine' not in secret_dict or secret_dict['engine'] != 'postgres':
+    if 'engine' not in secret_dict or 'postgres' not in secret_dict['engine']:
         raise KeyError("Database engine must be set to 'postgres' in order to use this rotation lambda")
     for field in required_fields:
         if field not in secret_dict:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If you using Aurora postgresql then rds api return engine to 'aurora-postgres'. 
So, I change code to check logic 'exact match' to 'contain match'.

It works well. I'm glad to additional suggest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
