### PR TITLE
feat: preserve former username and password

### DIFF
--- a/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
@@ -117,6 +117,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Preserve former username and password
+        current_dict['formerUsername'] = current_dict['username']
+        current_dict['formerPassword'] = current_dict['password']
+
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 

--- a/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
@@ -117,6 +117,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Preserve former username and password
+        current_dict['formerUsername'] = current_dict['username']
+        current_dict['formerPassword'] = current_dict['password']
+
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 

--- a/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
@@ -117,6 +117,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Preserve former username and password
+        current_dict['formerUsername'] = current_dict['username']
+        current_dict['formerPassword'] = current_dict['password']
+
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 

--- a/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
@@ -117,6 +117,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Preserve former username and password
+        current_dict['formerUsername'] = current_dict['username']
+        current_dict['formerPassword'] = current_dict['password']
+
         # Get the alternate username swapping between the original user and the user with _CLONE appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 

--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -33,6 +33,8 @@ def lambda_handler(event, context):
         'dbname': <optional: database name, default to 'postgres'>,
         'port': <optional: if not specified, default port 5432 will be used>,
         'masterarn': <required: the arn of the master secret which will be used to create users/change passwords>
+        'formerUsername': <optional: the username from before the last rotation>
+        'formerPassword': <optional: the password from before the last rotation>
     }
 
     Args:
@@ -119,6 +121,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Preserve former username and password
+        current_dict['formerUsername'] = current_dict['username']
+        current_dict['formerPassword'] = current_dict['password']
+
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 

--- a/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
@@ -117,6 +117,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Preserve former username and password
+        current_dict['formerUsername'] = current_dict['username']
+        current_dict['formerPassword'] = current_dict['password']
+
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 

--- a/SecretsManagerRedshiftRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRedshiftRotationMultiUser/lambda_function.py
@@ -116,6 +116,10 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
+        # Preserve former username and password
+        current_dict['formerUsername'] = current_dict['username']
+        current_dict['formerPassword'] = current_dict['password']
+
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
 


### PR DESCRIPTION
This enables the multiuser rotation to work with RDS Proxy.

*Issue #, if available:* #108

*Description of changes:*

Adds a `formerUsername` and `formerPassword` field on multiuser rotations, with the intention of enabling RDS Proxy to support multiuser rotations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
