### PR TITLE
add multi-user rotation support for RDS-managed Aurora Admin Secrets

### DIFF
--- a/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
@@ -473,7 +473,8 @@ def get_secret_dict(service_client, arn, stage, token=None, master_secret=False)
         if field not in secret_dict:
             raise KeyError("%s key is missing from secret JSON" % field)
 
-    if secret_dict['engine'] != 'mysql':
+    supported_engines = ["mysql", "aurora-mysql"]
+    if secret_dict['engine'] not in supported_engines:
         raise KeyError("Database engine must be set to 'mysql' in order to use this rotation lambda")
 
     # Parse and return the secret JSON string

--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -470,7 +470,8 @@ def get_secret_dict(service_client, arn, stage, token=None, master_secret=False)
         if field not in secret_dict:
             raise KeyError("%s key is missing from secret JSON" % field)
 
-    if secret_dict['engine'] != 'postgres':
+    supported_engines = ["postgres", "aurora-postgresql"]
+    if secret_dict['engine'] not in supported_engines:
         raise KeyError("Database engine must be set to 'postgres' in order to use this rotation lambda")
 
     # Parse and return the secret JSON string


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the RDS-managed Admin Secret case, the Mulit-User Rotation Lambda fetches the `engine` value from the `DescribeDBInstances` API. In the Aurora MySQL/PostgreSQL case, this `engine` value is returned as `aurora-mysql` and `aurora-postgresql`. This causes the Lambda to crash since we currently check that the engine value is exactly `mysql` or `postgres`.

This CR adds `aurora-mysql` and `aurora-postgresql` as valid `engine` values to the check so that the Lambda does not crash out-of-the-box for RDS Aurora customers with managed Admin Secrets that attempt Multi-User Rotation.

_This code change has already been live for a while, and customers have been receiving this updated code in newly-created Rotation Lambdas for a while, but this PR documents the code change in this public Github Repo._ 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
