### PR TITLE
fetch dbname from child secret + Tag key check

### DIFF
--- a/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationMultiUser/lambda_function.py
@@ -599,10 +599,15 @@ def fetch_instance_arn_from_system_tags(service_client, secret_arn):
 
     """
     metadata = service_client.describe_secret(SecretId=secret_arn)
-    global ARN_SYSTEM_TAG
+
+    if 'Tags' not in metadata:
+        logger.warning("setSecret: The secret %s is not a service-linked secret, so it does not have a tag aws:rds:primarydbinstancearn or a tag aws:rds:primarydbclusterarn" % secret_arn)
+        return None
+
     tags = metadata['Tags']
 
     # Check if DB Instance/Cluster ARN is present in secret Tags
+    global ARN_SYSTEM_TAG
     db_instance_arn = None
     for tag in tags:
         if tag['Key'].lower() == 'aws:rds:primarydbinstancearn' or tag['Key'].lower() == 'aws:rds:primarydbclusterarn':

--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -559,10 +559,15 @@ def fetch_instance_arn_from_system_tags(service_client, secret_arn):
     """
 
     metadata = service_client.describe_secret(SecretId=secret_arn)
-    global ARN_SYSTEM_TAG
+
+    if 'Tags' not in metadata:
+        logger.warning("setSecret: The secret %s is not a service-linked secret, so it does not have a tag aws:rds:primarydbinstancearn or a tag aws:rds:primarydbclusterarn" % secret_arn)
+        return None
+
     tags = metadata['Tags']
 
     # Check if DB Instance/Cluster ARN is present in secret Tags
+    global ARN_SYSTEM_TAG
     db_instance_arn = None
     for tag in tags:
         if tag['Key'].lower() == 'aws:rds:primarydbinstancearn' or tag['Key'].lower() == 'aws:rds:primarydbclusterarn':

--- a/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
@@ -186,6 +186,9 @@ def set_secret(service_client, arn, token):
     master_arn = current_dict['masterarn']
     master_dict = get_secret_dict(service_client, master_arn, "AWSCURRENT", None, True)
 
+    # Fetch dbname from the Child User, if present. In SQL Server, rotations at top level don't impact credentials in databases.
+    master_dict['dbname'] = current_dict.get('dbname', None)
+
     if current_dict['host'] != master_dict['host'] and not is_rds_replica_database(current_dict, master_dict):
         # If current dict is a replica of the master dict, can proceed
         logger.error("setSecret: Current database host %s is not the same host as/rds replica of master %s" % (current_dict['host'], master_dict['host']))
@@ -783,6 +786,11 @@ def fetch_instance_arn_from_system_tags(service_client, secret_arn):
     """
 
     metadata = service_client.describe_secret(SecretId=secret_arn)
+
+    if 'Tags' not in metadata:
+        logger.warning("setSecret: The secret %s is not a service-linked secret, so it does not have a tag aws:rds:primarydbinstancearn" % secret_arn)
+        return None
+
     tags = metadata['Tags']
 
     # Check if DB Instance ARN is present in secret Tags
@@ -839,7 +847,6 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
     primary_instance = instances[0]
     master_dict['host'] = primary_instance['Endpoint']['Address']
     master_dict['port'] = primary_instance['Endpoint']['Port']
-    master_dict['dbname'] = primary_instance.get('DBName', None)  # `DBName` doesn't have to be present.
     master_dict['engine'] = primary_instance['Engine']
 
     # simplify engine name to match `engine` Secret tag in the non-RDS-made Admin Secret flow


### PR DESCRIPTION
_Note: All of these changes have been public for a few months. This PR updates this code repository to match the code that is already being vended to customers when they create a new Rotation Lambda using this template._

*Issue #, if available:* N/A

*Description of changes:*
- We now fetch the `dbname` field from the Child Secret by default in the Multi-User Rotation flow. This enables the customer to modify the `dbname` value in the Child Secret to have more control over the Rotation. This also helps avoid some reported customer bugs.
- When determining whether to follow the Managed Rotation Multi-User Rotation scenario, we now do an exists check on the `Tags` key in the `describe_secret` result on the Admin Secret. Managed Admin Secrets will always have a `Tags` field in the Secret metadata. The `Tags` key check avoids Rotation Lambda failures in the non-Managed Admin Secret scenario where there are no Tags in the metadata.
