### PR TITLE
add support for multiple child user grants in Oracle

### DIFF
--- a/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
@@ -230,8 +230,10 @@ def set_secret(service_client, arn, token):
                             username=current_dict['username'].upper())
                 results = cur.fetchall()
                 for row in results:
-                    sql = row[0].read().strip(' \n\t').replace("%s" % escaped_current, "%s" % escaped_username)
-                    cur.execute(sql)
+                    # fetch and run all individual SQL commands needed to copy permissions to the new clone user
+                    sql_commands = row[0].read().strip(' \n\t').replace("%s" % escaped_current, "%s" % escaped_username)
+                    for sql_command in sql_commands.split('\n'):
+                        cur.execute(sql_command)
             except cx_Oracle.DatabaseError:
                 # If we were unable to find any grants skip this type
                 pass


### PR DESCRIPTION
_Note: All of these changes have been public for a few months. This PR updates this code repository to match the code that is already being vended to customers when they create a new Rotation Lambda using this template._

*Issue #, if available:* https://github.com/aws-samples/aws-secrets-manager-rotation-lambdas/issues/48

*Description of changes:*

There is a bug in our Multi-User Rotation Lambda code for Oracle where it crashes if the child user has more than 1 permission/grant in any of the 3 Grant categories (`'ROLE_GRANT'`, `'SYSTEM_GRANT'`, and `'OBJECT_GRANT'`).

We were alerted of this bug by a customer on Github, and they do a good job explaining the cause of the bug: https://github.com/aws-samples/aws-secrets-manager-rotation-lambdas/issues/48

The bug was caused by incorrectly using the `cx_Oracle` Python package's Oracle client. The `execute()` command can only execute 1 SQL command at a time. When copying over permissions to the new `_clone` user, our code ran all `GRANT` commands for all grants in a Grant category with a single `execute()` command, which throws the following error:

`ORA-00933: SQL command not properly ended`

This CR follows the customer's suggestions on fixing the bug. This CR makes sure we run one `execute()` command for each `GRANT` command when copying over permissions to the new `_clone` user.
