### PR TITLE
Add aurora engine support to postgres and mysql single user lambdas

### DIFF
--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -418,7 +418,8 @@ def get_secret_dict(service_client, arn, stage, token=None):
     secret_dict = json.loads(plaintext)
 
     # Run validations against the secret
-    if 'engine' not in secret_dict or secret_dict['engine'] != 'mysql':
+    supported_engines = ["mysql", "aurora-mysql"]
+    if secret_dict['engine'] not in supported_engines:
         raise KeyError("Database engine must be set to 'mysql' in order to use this rotation lambda")
     for field in required_fields:
         if field not in secret_dict:

--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
@@ -429,7 +429,8 @@ def get_secret_dict(service_client, arn, stage, token=None):
     secret_dict = json.loads(plaintext)
 
     # Run validations against the secret
-    if 'engine' not in secret_dict or secret_dict['engine'] != 'postgres':
+    supported_engines = ["postgres", "aurora-postgresql"]
+    if secret_dict['engine'] not in supported_engines:
         raise KeyError("Database engine must be set to 'postgres' in order to use this rotation lambda")
     for field in required_fields:
         if field not in secret_dict:


### PR DESCRIPTION
*Issue #129*

*Description of changes:*
In Pull Request #117 aurora engine types where added to 
- SecretsManagerRDSMySQLRotationMultiUser
- SecretsManagerRDSPostgreSQLRotationMultiUser

This change makes Postgres and MySQL lambdas consistent by also adding these engine types to the single user functions
- SecretsManagerRDSMySQLRotationSingleUser
- SecretsManagerRDSPostgreSQLRotationSingleUser

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
