### PR TITLE
Adding more granular random password generator options

### DIFF
--- a/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationMultiUser/lambda_function.py
@@ -119,12 +119,8 @@ def create_secret(service_client, arn, token):
     except service_client.exceptions.ResourceNotFoundException:
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
-
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -455,3 +451,49 @@ def get_alt_username(current_username):
         return current_username[:(len(clone_suffix) * -1)]
     else:
         return current_username + clone_suffix
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerMongoDBRotationSingleUser/lambda_function.py
+++ b/SecretsManagerMongoDBRotationSingleUser/lambda_function.py
@@ -114,11 +114,8 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -427,3 +424,49 @@ def get_secret_dict(service_client, arn, stage, token=None):
 
     # Parse and return the secret JSON string
     return secret_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSDb2RotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSDb2RotationMultiUser/lambda_function.py
@@ -119,12 +119,7 @@ def create_secret(service_client, arn, token):
     except service_client.exceptions.ResourceNotFoundException:
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
-
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\;'
-        # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -604,3 +599,49 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
     master_dict['dbname'] = "rdsadmin"
 
     return master_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\;'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationMultiUser/lambda_function.py
@@ -119,12 +119,7 @@ def create_secret(service_client, arn, token):
     except service_client.exceptions.ResourceNotFoundException:
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
-
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
-        # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -613,3 +608,49 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
     master_dict['engine'] = primary_instance['Engine']
 
     return master_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSMariaDBRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMariaDBRotationSingleUser/lambda_function.py
@@ -112,11 +112,8 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -423,3 +420,49 @@ def get_secret_dict(service_client, arn, stage, token=None):
 
     # Parse and return the secret JSON string
     return secret_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSMySQLRotationSingleUser/lambda_function.py
@@ -112,11 +112,8 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -446,3 +443,49 @@ def get_password_option(version):
         return "%s"
     else:
         return "PASSWORD(%s)"
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
@@ -49,7 +49,7 @@ def lambda_handler(event, context):
         KeyError: If the secret json does not contain the expected keys
 
     """
-    # Thick client to match full functionality of cx_oracle
+    # Thick client to match functionality of cx_oracle
     oracledb.init_oracle_client()
 
     arn = event['SecretId']
@@ -122,12 +122,7 @@ def create_secret(service_client, arn, token):
     except service_client.exceptions.ResourceNotFoundException:
         # Get the alternate username swapping between the original user and the user with _CLONE appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
-
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
-        # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters, PasswordLength=30)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -555,3 +550,49 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
         master_dict['engine'] = 'oracle'
 
     return master_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 30)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
@@ -44,7 +44,7 @@ def lambda_handler(event, context):
         KeyError: If the secret json does not contain the expected keys
 
     """
-    # Thick client to match full functionality of cx_oracle
+    # Thick client to match functionality of cx_oracle
     oracledb.init_oracle_client()
 
     arn = event['SecretId']
@@ -115,11 +115,8 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters, PasswordLength=30)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -346,3 +343,49 @@ def get_secret_dict(service_client, arn, stage, token=None):
 
     # Parse and return the secret JSON string
     return secret_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 30)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationMultiUser/lambda_function.py
@@ -121,12 +121,7 @@ def create_secret(service_client, arn, token):
     except service_client.exceptions.ResourceNotFoundException:
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
-
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else ':/@"\'\\'
-        # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -459,9 +454,9 @@ def get_secret_dict(service_client, arn, stage, token=None, master_secret=False)
         # If this is an RDS-made Master Secret, we can fetch `host` and other connection params
         # from the DescribeDBInstances/DescribeDBClusters RDS API using the DB Instance/Cluster ARN as a filter.
         # The DB Instance/Cluster ARN is fetched from the RDS-made Master Secret's System Tags.
-        db_instance_arn = fetch_instance_arn_from_system_tags(service_client, arn)
-        if db_instance_arn is not None:
-            secret_dict = get_connection_params_from_rds_api(secret_dict, db_instance_arn)
+        db_instance_info = fetch_instance_arn_from_system_tags(service_client, arn)
+        if len(db_instance_info) != 0:
+            secret_dict = get_connection_params_from_rds_api(secret_dict, db_instance_info)
             logger.info("setSecret: Successfully fetched connection params for Master Secret %s from DescribeDBInstances API." % arn)
 
         # For non-RDS-made Master Secrets that are missing `host`, this will error below when checking for required connection params.
@@ -554,37 +549,35 @@ def fetch_instance_arn_from_system_tags(service_client, secret_arn):
         secret_arn (String): The secret ARN used in a DescribeSecrets API call to fetch the secret's metadata.
 
     Returns:
-        db_instance_arn (String): The DB Instance/Cluster ARN of the Primary RDS Instance
+        db_instance_info (dict): The DB Instance/Cluster ARN of the Primary RDS Instance and the tag for the instance
 
     """
-
     metadata = service_client.describe_secret(SecretId=secret_arn)
 
     if 'Tags' not in metadata:
         logger.warning("setSecret: The secret %s is not a service-linked secret, so it does not have a tag aws:rds:primarydbinstancearn or a tag aws:rds:primarydbclusterarn" % secret_arn)
-        return None
+        return {}
 
     tags = metadata['Tags']
 
     # Check if DB Instance/Cluster ARN is present in secret Tags
-    global ARN_SYSTEM_TAG
-    db_instance_arn = None
+    db_instance_info = {}
     for tag in tags:
         if tag['Key'].lower() == 'aws:rds:primarydbinstancearn' or tag['Key'].lower() == 'aws:rds:primarydbclusterarn':
-            ARN_SYSTEM_TAG = tag['Key'].lower()
-            db_instance_arn = tag['Value']
+            db_instance_info['ARN_SYSTEM_TAG'] = tag['Key'].lower()
+            db_instance_info['ARN'] = tag['Value']
 
     # DB Instance/Cluster ARN must be present in secret System Tags to use this work-around
-    if db_instance_arn is None:
+    if len(db_instance_info) == 0:
         logger.warning("setSecret: DB Instance ARN not present in Metadata System Tags for secret %s" % secret_arn)
-    elif len(db_instance_arn) > MAX_RDS_DB_INSTANCE_ARN_LENGTH:
-        logger.error("setSecret: %s is not a valid DB Instance ARN. It exceeds the maximum length of %d." % (db_instance_arn, MAX_RDS_DB_INSTANCE_ARN_LENGTH))
-        raise ValueError("%s is not a valid DB Instance ARN. It exceeds the maximum length of %d." % (db_instance_arn, MAX_RDS_DB_INSTANCE_ARN_LENGTH))
+    elif len(db_instance_info['ARN']) > MAX_RDS_DB_INSTANCE_ARN_LENGTH:
+        logger.error("setSecret: %s is not a valid DB Instance ARN. It exceeds the maximum length of %d." % (db_instance_info['ARN'], MAX_RDS_DB_INSTANCE_ARN_LENGTH))
+        raise ValueError("%s is not a valid DB Instance ARN. It exceeds the maximum length of %d." % (db_instance_info['ARN'], MAX_RDS_DB_INSTANCE_ARN_LENGTH))
 
-    return db_instance_arn
+    return db_instance_info
 
 
-def get_connection_params_from_rds_api(master_dict, master_instance_arn):
+def get_connection_params_from_rds_api(master_dict, master_instance_info):
     """Fetches connection parameters (`host`, `port`, etc.) from the DescribeDBInstances/DescribeDBClusters RDS API using `master_instance_arn` in the master secret metadata as a filter.
 
     This helper function fetches connection parameters from the DescribeDBInstances/DescribeDBClusters RDS API using `master_instance_arn` in the master secret metadata as a filter.
@@ -592,7 +585,9 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
     Args:
         master_dict (dictionary): The master secret dictionary that will be updated with connection parameters.
 
-        master_instance_arn (string): The DB Instance/Cluster ARN from master secret System Tags that will be used as a filter in DescribeDBInstances/DescribeDBClusters RDS API calls.
+        master_instance_info (dict): A dictionary containing an 'ARN' and 'ARN_SYSTEM_TAG' key.
+            - The 'ARN_SYSTEM_TAG' value tells us if the DB is an instance or cluster so we know what 'Describe' RDS API to call and how to setup the connection parameters.
+            - The 'ARN' value is the DB Instance/Cluster ARN from master secret System Tags that will be used as a filter in DescribeDBInstances/DescribeDBClusters RDS API calls.
 
     Returns:
         master_dict (dictionary): An updated master secret dictionary that now contains connection parameters such as `host`, `port`, etc.
@@ -605,18 +600,18 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
     # Setup the client
     rds_client = boto3.client('rds')
 
-    if ARN_SYSTEM_TAG == 'aws:rds:primarydbinstancearn':
+    if master_instance_info['ARN_SYSTEM_TAG'] == 'aws:rds:primarydbinstancearn':
         # Call DescribeDBInstances RDS API
         try:
-            describe_response = rds_client.describe_db_instances(DBInstanceIdentifier=master_instance_arn)
+            describe_response = rds_client.describe_db_instances(DBInstanceIdentifier=master_instance_info['ARN'])
         except Exception as err:
             logger.error("setSecret: Encountered API error while fetching connection parameters from DescribeDBInstances RDS API: %s" % err)
             raise Exception("Encountered API error while fetching connection parameters from DescribeDBInstances RDS API: %s" % err)
         # Verify the instance was found
         instances = describe_response['DBInstances']
         if len(instances) == 0:
-            logger.error("setSecret: %s is not a valid DB Instance ARN. No Instances found when using DescribeDBInstances RDS API to get connection params." % master_instance_arn)
-            raise ValueError("%s is not a valid DB Instance ARN. No Instances found when using DescribeDBInstances RDS API to get connection params." % master_instance_arn)
+            logger.error("setSecret: %s is not a valid DB Instance ARN. No Instances found when using DescribeDBInstances RDS API to get connection params." % master_instance_info['ARN'])
+            raise ValueError("%s is not a valid DB Instance ARN. No Instances found when using DescribeDBInstances RDS API to get connection params." % master_instance_info['ARN'])
 
         # put connection parameters in master secret dictionary
         primary_instance = instances[0]
@@ -624,18 +619,18 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
         master_dict['port'] = primary_instance['Endpoint']['Port']
         master_dict['engine'] = primary_instance['Engine']
 
-    elif ARN_SYSTEM_TAG == 'aws:rds:primarydbclusterarn':
+    elif master_instance_info['ARN_SYSTEM_TAG'] == 'aws:rds:primarydbclusterarn':
         # Call DescribeDBClusters RDS API
         try:
-            describe_response = rds_client.describe_db_clusters(DBClusterIdentifier=master_instance_arn)
+            describe_response = rds_client.describe_db_clusters(DBClusterIdentifier=master_instance_info['ARN'])
         except Exception as err:
             logger.error("setSecret: Encountered API error while fetching connection parameters from DescribeDBClusters RDS API: %s" % err)
             raise Exception("Encountered API error while fetching connection parameters from DescribeDBClusters RDS API: %s" % err)
         # Verify the instance was found
         instances = describe_response['DBClusters']
         if len(instances) == 0:
-            logger.error("setSecret: %s is not a valid DB Cluster ARN. No Instances found when using DescribeDBClusters RDS API to get connection params." % master_instance_arn)
-            raise ValueError("%s is not a valid DB Cluster ARN. No Instances found when using DescribeDBClusters RDS API to get connection params." % master_instance_arn)
+            logger.error("setSecret: %s is not a valid DB Cluster ARN. No Instances found when using DescribeDBClusters RDS API to get connection params." % master_instance_info['ARN'])
+            raise ValueError("%s is not a valid DB Cluster ARN. No Instances found when using DescribeDBClusters RDS API to get connection params." % master_instance_info['ARN'])
 
         # put connection parameters in master secret dictionary
         primary_instance = instances[0]
@@ -644,3 +639,49 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
         master_dict['engine'] = primary_instance['Engine']
 
     return master_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', ':/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
@@ -114,12 +114,8 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else ':/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
-
+        current_dict['password'] = get_random_password(service_client)
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
         logger.info("createSecret: Successfully put secret for ARN %s and version %s." % (arn, token))
@@ -438,3 +434,49 @@ def get_secret_dict(service_client, arn, stage, token=None):
 
     # Parse and return the secret JSON string
     return secret_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', ':/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSSQLServerRotationMultiUser/lambda_function.py
@@ -119,12 +119,7 @@ def create_secret(service_client, arn, token):
     except service_client.exceptions.ResourceNotFoundException:
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
-
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
-        # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -854,3 +849,49 @@ def get_connection_params_from_rds_api(master_dict, master_instance_arn):
         master_dict['engine'] = 'sqlserver'
 
     return master_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRDSSQLServerRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSSQLServerRotationSingleUser/lambda_function.py
@@ -112,11 +112,8 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -449,3 +446,49 @@ def get_secret_dict(service_client, arn, stage, token=None):
 
     # Parse and return the secret JSON string
     return secret_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_NUMBERS
+        - EXCLUDE_PUNCTUATION
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludeNumbers=get_environment_bool('EXCLUDE_NUMBERS', False),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        ExcludeUppercase=get_environment_bool('EXCLUDE_UPPERCASE', False),
+        ExcludeLowercase=get_environment_bool('EXCLUDE_LOWERCASE', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRedshiftRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRedshiftRotationMultiUser/lambda_function.py
@@ -11,12 +11,14 @@ import pgdb
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+MAX_REDSHIFT_CLUSTER_ARN_LENGTH = 256
+
 
 def lambda_handler(event, context):
     """Secrets Manager Redshift Handler
 
-    This handler uses the master-user rotation scheme to rotate a Redshift user credential. During the first rotation, this
-    scheme logs into the database as the master user, creates a new user (appending _clone to the username), and grants the
+    This handler uses the admin-user rotation scheme to rotate a Redshift user credential. During the first rotation, this
+    scheme logs into the database as the admin user, creates a new user (appending _clone to the username), and grants the
     new user all of the permissions from the user being rotated. Once the secret is in this state, every subsequent rotation
     simply creates a new secret with the AWSPREVIOUS user credentials, changes that user's password, and then marks the
     latest secret as AWSCURRENT.
@@ -29,7 +31,7 @@ def lambda_handler(event, context):
         'password': <required: password>,
         'dbname': <optional: database name, default to 'dev'>,
         'port': <optional: if not specified, default port 5439 will be used>,
-        'masterarn': <required: the arn of the master secret which will be used to create users/change passwords>
+        'masterarn': <required: the arn of the admin secret which will be used to create users/change passwords>
     }
 
     Args:
@@ -118,12 +120,7 @@ def create_secret(service_client, arn, token):
     except service_client.exceptions.ResourceNotFoundException:
         # Get the alternate username swapping between the original user and the user with _clone appended to it
         current_dict['username'] = get_alt_username(current_dict['username'])
-
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\:'
-        # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -134,7 +131,7 @@ def set_secret(service_client, arn, token):
     """Set the pending secret in the database
 
     This method tries to login to the database with the AWSPENDING secret and returns on success. If that fails, it
-    tries to login with the master credentials from the masterarn in the current secret. If this succeeds, it adds all
+    tries to login with the admin credentials from the masterarn in the current secret. If this succeeds, it adds all
     grants for AWSCURRENT user to the AWSPENDING user, creating the user and/or setting the password in the process.
     Else, it throws a ValueError.
 
@@ -148,7 +145,7 @@ def set_secret(service_client, arn, token):
     Raises:
         ResourceNotFoundException: If the secret with the specified arn and stage does not exist
 
-        ValueError: If the secret is not valid JSON or master credentials could not be used to login to DB
+        ValueError: If the secret is not valid JSON or admin credentials could not be used to login to DB
 
         KeyError: If the secret json does not contain the expected keys
 
@@ -182,18 +179,22 @@ def set_secret(service_client, arn, token):
         raise ValueError("Unable to log into database using current credentials for secret %s" % arn)
     conn.close()
 
-    # Now get the master arn from the current secret
-    master_arn = current_dict['masterarn']
-    master_dict = get_secret_dict(service_client, master_arn, "AWSCURRENT")
-    if current_dict['host'] != master_dict['host']:
-        logger.error("setSecret: Current database host %s is not the same host as master %s" % (current_dict['host'], master_dict['host']))
-        raise ValueError("Current database host %s is not the same host as master %s" % (current_dict['host'], master_dict['host']))
+    # Use the admin arn from the current secret to fetch admin secret contents
+    admin_arn = current_dict['masterarn']
+    admin_dict = get_secret_dict(service_client, admin_arn, "AWSCURRENT", None, True)
 
-    # Now log into the database with the master credentials
-    conn = get_connection(master_dict)
+    # Fetch dbname from the Child User
+    admin_dict['dbname'] = current_dict.get('dbname', None)
+
+    if current_dict['host'] != admin_dict['host']:
+        logger.error("setSecret: Current database host %s is not the same host as admin %s" % (current_dict['host'], admin_dict['host']))
+        raise ValueError("Current database host %s is not the same host as admin %s" % (current_dict['host'], admin_dict['host']))
+
+    # Now log into the database with the admin credentials
+    conn = get_connection(admin_dict)
     if not conn:
-        logger.error("setSecret: Unable to log into database using credentials in master secret %s" % master_arn)
-        raise ValueError("Unable to log into database using credentials in master secret %s" % master_arn)
+        logger.error("setSecret: Unable to log into database using credentials in admin secret %s" % admin_arn)
+        raise ValueError("Unable to log into database using credentials in admin secret %s" % admin_arn)
 
     # Now set the password to the pending password
     try:
@@ -338,7 +339,7 @@ def get_connection(secret_dict):
     """
     # Parse and validate the secret JSON string
     port = int(secret_dict['port']) if 'port' in secret_dict else 5439
-    dbname = secret_dict['dbname'] if 'dbname' in secret_dict else "dev"
+    dbname = secret_dict['dbname'] if secret_dict.get('dbname') is not None else "dev"
 
     # Try to obtain a connection to the db
     try:
@@ -350,7 +351,7 @@ def get_connection(secret_dict):
         return None
 
 
-def get_secret_dict(service_client, arn, stage, token=None):
+def get_secret_dict(service_client, arn, stage, token=None, admin_secret=False):
     """Gets the secret dictionary corresponding for the secret arn, stage, and token
 
     This helper function gets credentials for the arn and stage passed in and returns the dictionary by parsing the JSON string
@@ -360,9 +361,11 @@ def get_secret_dict(service_client, arn, stage, token=None):
 
         arn (string): The secret ARN or other identifier
 
+        stage (string): The stage identifying the secret version
+
         token (string): The ClientRequestToken associated with the secret version, or None if no validation is desired
 
-        stage (string): The stage identifying the secret version
+        admin_secret (boolean): A flag that indicates if we are getting an admin secret.
 
     Returns:
         SecretDictionary: Secret dictionary
@@ -375,7 +378,7 @@ def get_secret_dict(service_client, arn, stage, token=None):
         KeyError: If the secret json does not contain the expected keys
 
     """
-    required_fields = ['host', 'username', 'password']
+    required_fields = ['host', 'username', 'password', 'engine']
 
     # Only do VersionId validation against the stage if a token is passed in
     if token:
@@ -385,12 +388,38 @@ def get_secret_dict(service_client, arn, stage, token=None):
     plaintext = secret['SecretString']
     secret_dict = json.loads(plaintext)
 
-    # Run validations against the secret
-    if 'engine' not in secret_dict or secret_dict['engine'] != 'redshift':
-        raise KeyError("Database engine must be set to 'redshift' in order to use this rotation lambda")
+    # Get tags associated with the secret if it is an admin secret
+    if admin_secret:
+        tags = get_tags_from_metadata(service_client, arn)
+        # Fetch tag and tag type (redshift or redshift-serverless) from Redshift service-linked secrets
+        redshift_system_tag_and_type = fetch_redshift_system_tag_from_tags(tags, arn)
+
+        # Only fetch connection parameters if the secret is a service-linked secret, the parameter is set to None for non service-linked secrets
+        if redshift_system_tag_and_type is not None:
+            redshift_system_tag = redshift_system_tag_and_type[0]
+            redshift_tag_type = redshift_system_tag_and_type[1]
+
+            # Validate cluster_arn length before getting connection parameters
+            cluster_arn = redshift_system_tag['Value']
+            validate_cluster_arn(cluster_arn)
+
+            # For Redshift service-linked secrets, use the cluster ARN to retrieve connection parameters from the Redshift APIs.
+            if redshift_tag_type == "redshift-serverless":
+                secret_dict = get_connection_params_from_redshift_serverless_api(secret_dict, cluster_arn)
+            else:
+                secret_dict = get_connection_params_from_redshift_api(secret_dict, cluster_arn)
+            logger.info("setSecret: Successfully fetched connection params for the admin secret %s from the Redshift API." % arn)
+
+            # Hardcode 'redshift' engine because this is a Redshift service-linked secret
+            secret_dict['engine'] = 'redshift'
+
     for field in required_fields:
         if field not in secret_dict:
             raise KeyError("%s key is missing from secret JSON" % field)
+
+    # Run validations against the secret
+    if secret_dict['engine'] != 'redshift':
+        raise KeyError("Database engine must be set to 'redshift' in order to use this rotation lambda")
 
     # Parse and return the secret JSON string
     return secret_dict
@@ -416,3 +445,223 @@ def get_alt_username(current_username):
         return current_username[:(len(clone_suffix) * -1)]
     else:
         return current_username + clone_suffix
+
+
+def fetch_redshift_system_tag_from_tags(tags, secret_arn):
+    """Checks the secret for a tag with the Redshift cluster ARN. Only Redshift service-linked secrets will contain this tag.
+
+    Args:
+        tags (List of Tags): The tags contained in the secret metadata used to determine if the secret is a service-linked-secret or not.
+
+        secret_arn (String): The secret ARN used in a DescribeSecrets API call to fetch the secret's metadata.
+
+    Returns:
+        (tag,type): Returns the Redshift System tag along with the type (redshift or redshift-serverless) if there is one, None otherwise
+
+    """
+
+    if not tags:
+        logger.warning("setSecret: The secret %s is not a service-linked secret, so it does not have a tag aws:redshift:primaryclusterarn or aws:redshift-serverless:namespacearn" % secret_arn)
+        return None
+
+    for tag in tags:
+        if tag['Key'].lower() == 'aws:redshift-serverless:namespacearn':
+            return (tag, "redshift-serverless")
+        elif tag['Key'].lower() == 'aws:redshift:primaryclusterarn':
+            return (tag, "redshift")
+
+    logger.warning("setSecret: The secret %s is not a service-linked secret, so it does not have a tag aws:redshift:primaryclusterarn or aws:redshift-serverless:namespacearn" % secret_arn)
+    return None
+
+
+def get_tags_from_metadata(service_client, secret_arn):
+    """Retrieves the tags associated with the service-linked secret
+
+    Args:
+        service_client (client): The secrets manager service client
+
+        secret_arn (String): The secret ARN used in a DescribeSecrets API call to fetch the secret's metadata.
+
+    Returns:
+        tags (list): The list of tags associated with the secret
+
+    """
+    metadata = service_client.describe_secret(SecretId=secret_arn)
+    tags = metadata.get('Tags')
+
+    return tags
+
+
+def validate_cluster_arn(cluster_arn):
+    """Validates cluster ARN length obtained from the Redshift System tag of the service-linked secret
+
+    Args:
+        cluster_arn: The Redshift Cluster ARN of the service-linked secret
+
+    Raises:
+        ValueError: If the cluster_arn length is greater than the maximum ARN length
+
+    """
+
+    if len(cluster_arn) > MAX_REDSHIFT_CLUSTER_ARN_LENGTH:
+        logger.error("setSecret: The secret has a tag aws:redshift:primaryclusterarn or aws:redshift-serverless:namespacearn, but the ARN in the tag exceeds the maximum length %d." % MAX_REDSHIFT_CLUSTER_ARN_LENGTH)
+        raise ValueError("The secret has a tag aws:redshift:primaryclusterarn or aws:redshift-serverless:namespacearn, but the ARN in the tag exceeds the maximum length %d." % MAX_REDSHIFT_CLUSTER_ARN_LENGTH)
+
+
+def get_connection_params_from_redshift_serverless_api(admin_dict, namespace_arn):
+    """Gets connection parameters such as host and port for the specified Redshift Serverless Instance
+
+    This helper function uses the Redshift Serverless APIs to get connection parameters for the specified Redshift Namespace
+
+    Args:
+        admin_dict (dictionary): The admin secret dictionary that will be updated with connection parameters.
+
+        namespace_arn (string): The namespace ARN used to find the workgroup associated with it.
+
+    Returns:
+        admin_dict (dictionary): An updated admin secret dictionary that now contains connection parameters such as `host` and `port`.
+
+     Raises:
+        Exception: If Redshift Serverless API returns an error
+
+        ValueError: If the Redshift ListWorkgroups or ListNamespaces API's response contains no instances corresponding to the NamespaceId
+
+    """
+    # Set up the Redshift Serverless client
+    redshift_serverless_client = boto3.client('redshift-serverless')
+
+    if len(namespace_arn) == 0:
+        logger.error("setSecret: The secret has a tag aws:redshift-serverless:namespacearn, but Redshift can't find namespace %s" % namespace_arn)
+        raise ValueError("The secret has a tag aws:redshift-serverless:namespacearn, but Redshift can't find namespace %s" % namespace_arn)
+
+    namespace_name = None
+    # Call listNamespaces API to get namespaceName corresponding to the namespace_arn
+    try:
+        namespace_response = redshift_serverless_client.list_namespaces(maxResults=100)
+        namespaces = namespace_response['namespaces']
+    except Exception as err:
+        logger.error("setSecret: Encountered API error while fetching connection parameters from ListNamespaces Redshift Serverless API: %s" % err)
+        raise Exception("Encountered API error while fetching connection parameters from ListNamespaces Redshift Serverless API: %s" % err)
+
+    for namespace in namespaces:
+        if namespace_arn == namespace['namespaceArn']:
+            namespace_name = namespace['namespaceName']
+            break
+
+    if not namespace_name:
+        logger.error("setSecret: The secret has a tag aws:redshift-serverless:namespacearn, but Redshift can't find namespace %s" % namespace_arn)
+        raise ValueError("The secret has a tag aws:redshift-serverless:namespacearn, but Redshift can't find namespace %s" % namespace_arn)
+
+    admin_workgroup = None
+    # Call the ListWorkgroups API to find the workgroup associated with the namespace, to get the host and port details
+    try:
+        workgroup_response = redshift_serverless_client.list_workgroups(maxResults=100)
+        workgroups = workgroup_response['workgroups']
+    except Exception as err:
+        logger.error("setSecret: Encountered API error while fetching connection parameters from ListWorkgroups Redshift Serverless API: %s" % err)
+        raise Exception("Encountered API error while fetching connection parameters from ListWorkgroups Redshift Serverless API: %s" % err)
+
+    for workgroup in workgroups:
+        if namespace_name == workgroup['namespaceName']:
+            admin_workgroup = workgroup
+            break
+
+    if not admin_workgroup:
+        logger.error("setSecret: The secret has a tag aws:redshift-serverless:namespacearn, but Redshift can't find workgroup associated with %s" % namespace_arn)
+        raise ValueError("The secret has a tag aws:redshift-serverless:namespacearn, but Redshift can't find workgroup associated with %s" % namespace_arn)
+
+    admin_dict['host'] = admin_workgroup['endpoint']['address']
+    admin_dict['port'] = admin_workgroup['endpoint']['port']
+
+    return admin_dict
+
+
+def get_connection_params_from_redshift_api(admin_dict, admin_cluster_arn):
+    """Gets connection parameters such as host and port for the specified Redshift cluster
+
+    This helper function uses the Redshift DescribeClusters API to get connection parameters for the specified Redshift cluster
+
+    Args:
+        admin_dict (dictionary): The admin secret dictionary that will be updated with connection parameters.
+
+        admin_cluster_arn (string): The cluster ARN to use as a filter in DescribeClusters Redshift API calls.
+
+    Returns:
+        admin_dict (dictionary): An updated admin secret dictionary that now contains connection parameters such as `host` and `port`.
+
+    Raises:
+        Exception: If Redshift DescribeClusters API returns an error
+
+        ValueError: If the Redshift DescribeClusters API's response contains no instances or more than one instance
+    """
+    # Setup the Redshift client
+    redshift_client = boto3.client('redshift')
+
+    # extract the cluster identifier from the cluster ARN
+    cluster_identifier = admin_cluster_arn.split(":")[-1]
+
+    # Call DescribeClusters Redshift API
+    try:
+        describe_response = redshift_client.describe_clusters(ClusterIdentifier=cluster_identifier)
+    except Exception as err:
+        logger.error("setSecret: Encountered API error while fetching connection parameters from DescribeClusters Redshift API: %s" % err)
+        raise Exception("Encountered API error while fetching connection parameters from DescribeClusters Redshift API: %s" % err)
+
+    # Verify the instance was found
+    clusters = describe_response['Clusters']
+    if len(clusters) == 0:
+        logger.error("setSecret: The secret has a tag aws:redshift:primaryclusterarn, but Redshift can't find the cluster defined in the tag: %s" % admin_cluster_arn)
+        raise ValueError("The secret has a tag aws:redshift:primaryclusterarn, but Redshift can't find the cluster defined in the tag: %s" % admin_cluster_arn)
+
+    # put connection parameters in admin secret dictionary
+    primary_cluster = clusters[0]
+    admin_dict['host'] = primary_cluster['Endpoint']['Address']
+    admin_dict['port'] = primary_cluster['Endpoint']['Port']
+
+    return admin_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_PUNCTUATION
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Redshift requires password to have at least one lower, one upper case and one number character. Because of that
+    following options are omitted:
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - EXCLUDE_NUMBERS
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\:'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRedshiftRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRedshiftRotationSingleUser/lambda_function.py
@@ -113,11 +113,8 @@ def create_secret(service_client, arn, token):
         get_secret_dict(service_client, arn, "AWSPENDING", token)
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
-        # Get exclude characters from environment variable
-        exclude_characters = os.environ['EXCLUDE_CHARACTERS'] if 'EXCLUDE_CHARACTERS' in os.environ else '/@"\'\\:'
         # Generate a random password
-        passwd = service_client.get_random_password(ExcludeCharacters=exclude_characters)
-        current_dict['password'] = passwd['RandomPassword']
+        current_dict['password'] = get_random_password(service_client)
 
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
@@ -345,3 +342,49 @@ def get_secret_dict(service_client, arn, stage, token=None):
 
     # Parse and return the secret JSON string
     return secret_dict
+
+
+def get_environment_bool(variable_name, default_value):
+    """Loads the environment variable and converts it to the boolean.
+
+    Args:
+        variable_name (string): Name of environment variable
+
+        default_value (bool): The result will fallback to the default_value when the environment variable with the given name doesn't exist.
+
+    Returns:
+        bool: True when the content of environment variable contains either 'true', '1', 'y' or 'yes'
+    """
+    variable = os.environ.get(variable_name, str(default_value))
+    return variable.lower() in ['true', '1', 'y', 'yes']
+
+
+def get_random_password(service_client):
+    """ Generates a random new password. Generator loads parameters that affects the content of the resulting password from the environment
+    variables. When environment variable is missing sensible defaults are chosen.
+
+    Supported environment variables:
+        - EXCLUDE_CHARACTERS
+        - PASSWORD_LENGTH
+        - EXCLUDE_PUNCTUATION
+        - REQUIRE_EACH_INCLUDED_TYPE
+
+    Redshift requires password to have at least one lower, one upper case and one number character. Because of that
+    following options are omitted:
+        - EXCLUDE_UPPERCASE
+        - EXCLUDE_LOWERCASE
+        - EXCLUDE_NUMBERS
+
+    Args:
+        service_client (client): The secrets manager service client
+
+    Returns:
+        string: The randomly generated password.
+    """
+    passwd = service_client.get_random_password(
+        ExcludeCharacters=os.environ.get('EXCLUDE_CHARACTERS', '/@"\'\\:'),
+        PasswordLength=int(os.environ.get('PASSWORD_LENGTH', 32)),
+        ExcludePunctuation=get_environment_bool('EXCLUDE_PUNCTUATION', False),
+        RequireEachIncludedType=get_environment_bool('REQUIRE_EACH_INCLUDED_TYPE', True)
+    )
+    return passwd['RandomPassword']

--- a/SecretsManagerRotationTemplate/lambda_function.py
+++ b/SecretsManagerRotationTemplate/lambda_function.py
@@ -129,9 +129,6 @@ def test_secret(service_client, arn, token):
     is a database credential, this method should validate that the user can login with the password in AWSPENDING and that the user has
     all of the expected permissions against the database.
 
-    If the test fails, this function should raise an exception. (Any exception.)
-    If no exception is raised, the test is considered to have passed. (The return value is ignored.)
-
     Args:
         service_client (client): The secrets manager service client
 


### PR DESCRIPTION
Its now possible to specify new random password generation options via environment variables. Newly supported options are:

- PASSWORD_LENGTH
- EXCLUDE_NUMBERS
- EXCLUDE_PUNCTUATION
- EXCLUDE_UPPERCASE
- EXCLUDE_LOWERCASE
- REQUIRE_EACH_INCLUDED_TYPE

These are just pass thought parameters to the [GenerateSecretString](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-secret-generatesecretstring.html)
