### PR TITLE
Fix Redshift multi user rotation Lambda for users with datashare permission

### DIFF
--- a/SecretsManagerRedshiftRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRedshiftRotationMultiUser/lambda_function.py
@@ -217,7 +217,8 @@ def set_secret(service_client, arn, token):
                                 (current_dict['username'], perm))
                     databases = [row.datname for row in cur.fetchall()]
                     if databases:
-                        cur.execute("GRANT %s ON DATABASE %s TO %s" % (perm, ','.join(databases), pending_username))
+                        for database in databases:
+                            cur.execute("GRANT %s ON DATABASE %s TO %s" % (perm, database, pending_username))
 
                 # Grant table permissions
                 table_perm_types = ['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'REFERENCES']


### PR DESCRIPTION
*Issue #, if available:*
If a user has access to DB created from datashare as well as regular DB and the Redshift multi user rotation Lambda attempts to rotate the user's credential, the error `Cannot grant privilege to databases created from datashares and normal databases in one statement.` comes up. 

*Description of changes:*
Split up grant perm statement. Iterate through the list of databases that current user has perm on and grant privilege on one database at a time to the pending user, instead of granting perm on a list of databases in a single statement.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
