### PR TITLE
Add propagation time before testSecret within SecretsManagerRDSDb2Rot…

### DIFF
--- a/SecretsManagerRDSDb2RotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSDb2RotationSingleUser/lambda_function.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
+import time
 
 import boto3
 import json
@@ -76,6 +77,9 @@ def lambda_handler(event, context):
 
     elif step == "setSecret":
         set_secret(service_client, arn, token)
+        # Wait for 10s to allow propagation of the newly set AWSPENDING password as the user password in the database.
+        # The database user password change is asynchronous.
+        time.sleep(10)
 
     elif step == "testSecret":
         test_secret(service_client, arn, token)


### PR DESCRIPTION
*Issue #, if available:*
- SecretsManagerRDSDb2RotationSingleUser lambda always failed in its first rotation attempt at step testSecret due to not being able to log into database with pending secret. Root cause is password change is asynchronous, and it takes time to propagate.

*Description of changes:*
- Add 10s propagation time as per the RDS DB2 team guidance at the end of setSecret step. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
