### PR TITLE
Remove AWSPending state

### DIFF
--- a/SecretsManagerRotationTemplate/lambda_function.py
+++ b/SecretsManagerRotationTemplate/lambda_function.py
@@ -171,4 +171,5 @@ def finish_secret(service_client, arn, token):
 
     # Finalize by staging the secret version current
     service_client.update_secret_version_stage(SecretId=arn, VersionStage="AWSCURRENT", MoveToVersionId=token, RemoveFromVersionId=current_version)
+    service_client.update_secret_version_stage(SecretId=arn, VersionStage="AWSPENDING", RemoveFromVersionId=token)
     logger.info("finishSecret: Successfully set AWSCURRENT stage to version %s for secret %s." % (token, arn))


### PR DESCRIPTION
The newly added key will have both states (AWSCURRENT, AWSPENDING). You can monitor this behavior in the AWS Secrets Manager console. With this line of code, the pending state is removed from the newly assigned key version.
