### PR TITLE
Issue 157: FIX:CWE-117,93 Log injection in PostgreSQL lambda_function.py

### DIFF
--- a/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSPostgreSQLRotationSingleUser/lambda_function.py
@@ -56,17 +56,17 @@ def lambda_handler(event, context):
     # Make sure the version is staged correctly
     metadata = service_client.describe_secret(SecretId=arn)
     if "RotationEnabled" in metadata and not metadata['RotationEnabled']:
-        logger.error("Secret %s is not enabled for rotation" % arn)
-        raise ValueError("Secret %s is not enabled for rotation" % arn)
+        logger.error("Secret %s is not enabled for rotation" % arn.encode())
+        raise ValueError("Secret %s is not enabled for rotation" % arn.encode())
     versions = metadata['VersionIdsToStages']
     if token not in versions:
-        logger.error("Secret version %s has no stage for rotation of secret %s." % (token, arn))
+        logger.error("Secret version %s has no stage for rotation of secret %s." % (token.encode(), arn.encode()))
         raise ValueError("Secret version %s has no stage for rotation of secret %s." % (token, arn))
     if "AWSCURRENT" in versions[token]:
-        logger.info("Secret version %s already set as AWSCURRENT for secret %s." % (token, arn))
+        logger.info("Secret version %s already set as AWSCURRENT for secret %s." % (token.encode(), arn.encode()))
         return
     elif "AWSPENDING" not in versions[token]:
-        logger.error("Secret version %s not set as AWSPENDING for rotation of secret %s." % (token, arn))
+        logger.error("Secret version %s not set as AWSPENDING for rotation of secret %s." % (token.encode(), arn.encode()))
         raise ValueError("Secret version %s not set as AWSPENDING for rotation of secret %s." % (token, arn))
 
     # Call the appropriate step
@@ -83,7 +83,7 @@ def lambda_handler(event, context):
         finish_secret(service_client, arn, token)
 
     else:
-        logger.error("lambda_handler: Invalid step parameter %s for secret %s" % (step, arn))
+        logger.error("lambda_handler: Invalid step parameter %s for secret %s" % (step.encode(), arn.encode()))
         raise ValueError("Invalid step parameter %s for secret %s" % (step, arn))
 
 
@@ -112,13 +112,13 @@ def create_secret(service_client, arn, token):
     # Now try to get the secret version, if that fails, put a new secret
     try:
         get_secret_dict(service_client, arn, "AWSPENDING", token)
-        logger.info("createSecret: Successfully retrieved secret for %s." % arn)
+        logger.info("createSecret: Successfully retrieved secret for %s." % arn.encode())
     except service_client.exceptions.ResourceNotFoundException:
         # Generate a random password
         current_dict['password'] = get_random_password(service_client)
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
-        logger.info("createSecret: Successfully put secret for ARN %s and version %s." % (arn, token))
+        logger.info("createSecret: Successfully put secret for ARN %s and version %s." % (arn.encode(), token.encode()))
 
 
 def set_secret(service_client, arn, token):
@@ -154,7 +154,7 @@ def set_secret(service_client, arn, token):
     conn = get_connection(pending_dict)
     if conn:
         conn.close()
-        logger.info("setSecret: AWSPENDING secret is already set as password in PostgreSQL DB for secret arn %s." % arn)
+        logger.info("setSecret: AWSPENDING secret is already set as password in PostgreSQL DB for secret arn %s." % arn.encode())
         return
 
     # Make sure the user from current and pending match
@@ -189,7 +189,7 @@ def set_secret(service_client, arn, token):
 
     # If we still don't have a connection, raise a ValueError
     if not conn:
-        logger.error("setSecret: Unable to log into database with previous, current, or pending secret of secret arn %s" % arn)
+        logger.error("setSecret: Unable to log into database with previous, current, or pending secret of secret arn %s" % arn.encode())
         raise ValueError("Unable to log into database with previous, current, or pending secret of secret arn %s" % arn)
 
     # Now set the password to the pending password
@@ -202,7 +202,7 @@ def set_secret(service_client, arn, token):
             alter_role = "ALTER USER %s" % escaped_username
             cur.execute(alter_role + " WITH PASSWORD %s", (pending_dict['password'],))
             conn.commit()
-            logger.info("setSecret: Successfully set password for user %s in PostgreSQL DB for secret arn %s." % (pending_dict['username'], arn))
+            logger.info("setSecret: Successfully set password for user %s in PostgreSQL DB for secret arn %s." % (pending_dict['username'], arn.encode()))
     finally:
         conn.close()
 
@@ -240,10 +240,10 @@ def test_secret(service_client, arn, token):
         finally:
             conn.close()
 
-        logger.info("testSecret: Successfully signed into PostgreSQL DB with AWSPENDING secret in %s." % arn)
+        logger.info("testSecret: Successfully signed into PostgreSQL DB with AWSPENDING secret in %s." % arn.encode())
         return
     else:
-        logger.error("testSecret: Unable to log into database with pending secret of secret ARN %s" % arn)
+        logger.error("testSecret: Unable to log into database with pending secret of secret ARN %s" % arn.encode())
         raise ValueError("Unable to log into database with pending secret of secret ARN %s" % arn)
 
 
@@ -267,14 +267,14 @@ def finish_secret(service_client, arn, token):
         if "AWSCURRENT" in metadata["VersionIdsToStages"][version]:
             if version == token:
                 # The correct version is already marked as current, return
-                logger.info("finishSecret: Version %s already marked as AWSCURRENT for %s" % (version, arn))
+                logger.info("finishSecret: Version %s already marked as AWSCURRENT for %s" % (version, arn.encode()))
                 return
             current_version = version
             break
 
     # Finalize by staging the secret version current
     service_client.update_secret_version_stage(SecretId=arn, VersionStage="AWSCURRENT", MoveToVersionId=token, RemoveFromVersionId=current_version)
-    logger.info("finishSecret: Successfully set AWSCURRENT stage to version %s for secret %s." % (token, arn))
+    logger.info("finishSecret: Successfully set AWSCURRENT stage to version %s for secret %s." % (token.encode(), arn.encode()))
 
 
 def get_connection(secret_dict):


### PR DESCRIPTION
*Issue # 157*

*Description of changes:*
HIGH-Severity Security Vulnerability from AWS-Inspector.
`CWE-117,93 Log injection`
----------
Analysis:
> HIGH-Severity Security Vulnerability from AWS-Inspector.
> `CWE-117,93 Log injection`
> The PostgreSQL-related Lambdas have 3 "input" variables: `arn` `token` and `step`.
> With no attempt to sanitize these inputs, these variables are logged using `logger`.

----------
*Even tho' these lambdas are NOT expected to be connected to APIGW, and are meant to be invoked via EventBridge-Cron, .. the AWS-Inspector, and other security-tools, will NEVER be able to confirm this, and so will continue to flag ALL Log-related vulnerabilities as high.
----------
Since the FIX is trivial (add `.encode()` to EACH and EVERY logger-statement) and .. ..
.. Since the primary-code is UNTOUCHED (as in, we are NOT choosing to "fix" these 3 input-variables), ..
it is quite reasonable to conclude that there should be ZERO functional impact (that is, No new errors introduced).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
