### PR TITLE
Initialize Oracle client in lambda_handler for oracle

### DIFF
--- a/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationMultiUser/lambda_function.py
@@ -50,6 +50,9 @@ def lambda_handler(event, context):
 
     """
 
+    # Thick client to match functionality of cx_oracle
+    oracledb.init_oracle_client()
+
     arn = event['SecretId']
     token = event['ClientRequestToken']
     step = event['Step']

--- a/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
@@ -45,6 +45,9 @@ def lambda_handler(event, context):
 
     """
 
+    # Thick client to match functionality of cx_oracle
+    oracledb.init_oracle_client()
+
     arn = event['SecretId']
     token = event['ClientRequestToken']
     step = event['Step']


### PR DESCRIPTION
*Issue #163*

*Description of changes:*

Add thick client initialization back into oracle rotation so connections to databases with allow_weak_crypto set to false work.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
