### PR TITLE
Add Oracle thick mode support via ORACLE_THICK_MODE env var

### DIFF
--- a/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
@@ -11,6 +11,22 @@ import re
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+# Enable Oracle Thick mode if requested via environment variable.
+# Thick mode is required for features such as Native Network Encryption (NNE),
+# checksumming, Kerberos authentication, and connections to Oracle DB versions
+# prior to 12.1. When enabled, Oracle Instant Client libraries must be available
+# in the system library search path (LD_LIBRARY_PATH). A Lambda Layer containing
+# Oracle Instant Client Basic Lite and libaio.so.1 is the recommended approach.
+#
+# Supported environment variables for thick mode:
+#   - ORACLE_THICK_MODE: Set to 'true' to enable thick mode (default: false)
+#   - ORACLE_CLIENT_CONFIG_DIR: Optional path to Oracle Net config files
+#     (tnsnames.ora, sqlnet.ora). Defaults to None (uses standard search paths).
+if os.environ.get('ORACLE_THICK_MODE', 'false').lower() in ['true', '1', 'y', 'yes']:
+    config_dir = os.environ.get('ORACLE_CLIENT_CONFIG_DIR')
+    oracledb.init_oracle_client(config_dir=config_dir)
+    logger.info("Oracle Thick mode enabled (config_dir=%s)" % config_dir)
+
 
 def lambda_handler(event, context):
     """Secrets Manager RDS Oracle Handler
@@ -26,7 +42,8 @@ def lambda_handler(event, context):
         'username': <required: username>,
         'password': <required: password>,
         'dbname': <required: database name>,
-        'port': <optional: if not specified, default port 1521 will be used>
+        'port': <optional: if not specified, default port 1521 will be used>,
+        'ssl': <optional: if not specified, SSL with fallback is used>
     }
 
     Args:
@@ -197,7 +214,7 @@ def set_secret(service_client, arn, token):
     pending_password = pending_dict['password'].replace("\"", "")
 
     # Now set the password to the pending password
-    sql = "ALTER USER %s IDENTIFIED BY \"%s\"" % (escaped_username, pending_dict['password'])
+    sql = "ALTER USER %s IDENTIFIED BY \"%s\"" % (escaped_username, pending_password)
     cur.execute(sql)
     conn.commit()
     logger.info("setSecret: Successfully set password for user %s in Oracle DB for secret arn %s." % (pending_dict['username'], arn))

--- a/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
+++ b/SecretsManagerRDSOracleRotationSingleUser/lambda_function.py
@@ -42,8 +42,7 @@ def lambda_handler(event, context):
         'username': <required: username>,
         'password': <required: password>,
         'dbname': <required: database name>,
-        'port': <optional: if not specified, default port 1521 will be used>,
-        'ssl': <optional: if not specified, SSL with fallback is used>
+        'port': <optional: if not specified, default port 1521 will be used>
     }
 
     Args:
@@ -214,7 +213,7 @@ def set_secret(service_client, arn, token):
     pending_password = pending_dict['password'].replace("\"", "")
 
     # Now set the password to the pending password
-    sql = "ALTER USER %s IDENTIFIED BY \"%s\"" % (escaped_username, pending_password)
+    sql = "ALTER USER %s IDENTIFIED BY \"%s\"" % (escaped_username, pending_dict['password'])
     cur.execute(sql)
     conn.commit()
     logger.info("setSecret: Successfully set password for user %s in Oracle DB for secret arn %s." % (pending_dict['username'], arn))


### PR DESCRIPTION
## Summary

This PR adds configurable Oracle Thick mode support to the SecretsManagerRDSOracleRotationSingleUser template.

## Changes

### Oracle Thick Mode Toggle

Adds module-level initialization that checks the ORACLE_THICK_MODE environment variable. When enabled, calls oracledb.init_oracle_client() before any connection is created. This is required for customers whose Oracle databases enforce Native Network Encryption (NNE), checksumming, or Kerberos authentication, features that only work in python-oracledb's Thick mode.

New environment variables:
- ORACLE_THICK_MODE (default: false) — set to true to enable
- ORACLE_CLIENT_CONFIG_DIR (optional) — path to Oracle Net config files

When enabled, Oracle Instant Client libraries must be available via LD_LIBRARY_PATH (e.g., via a Lambda Layer).

Backward compatible, default behavior (thin mode) is unchanged.

## Testing

Tested against Oracle Database Free (26ai) running on EC2 with Native Network Encryption set to REQUIRED:

| Scenario | Result |
|----------|--------|
| Original code, NNE REQUIRED, thin mode | DPY-4011: the database or network closed the connection |
| Updated code, NNE REQUIRED, thick mode enabled | Full rotation cycle passes |

## Note

The same change should be applied to SecretsManagerRDSOracleRotationMultiUser as well.

## Related

- python-oracledb confirms NNE will not be added to thin mode: https://github.com/oracle/node-oracledb/issues/1557
- python-oracledb thin vs thick mode docs: https://python-oracledb.readthedocs.io/en/latest/user_guide/appendix_b.html